### PR TITLE
Fix data races

### DIFF
--- a/pkg/protocol/grpc/server.go
+++ b/pkg/protocol/grpc/server.go
@@ -37,7 +37,8 @@ func RunServer(ctx context.Context, v1API v1.SimulationServiceServer, port strin
 			// sig is a ^C, handle it
 			logger.Log.Warn("shutting down gRPC server...")
 
-			server.GracefulStop()
+			// Not graceful stop because Spectate RPCs will never complete
+			server.Stop()
 
 			logger.Log.Warn("grpc server shut down!")
 

--- a/pkg/service/v1/auth.go
+++ b/pkg/service/v1/auth.go
@@ -20,7 +20,7 @@ func initializeFirebaseApp(env string) *firebase.App {
 	// TESTING FUNCTIONALITY
 	// -----------------------------------
 	//Return a testing token with fake uid
-	if env == "testing" {
+	if env == "testing" || env == "debug" {
 		return nil
 	}
 	// -----------------------------------
@@ -50,7 +50,7 @@ func verifyFirebaseIDToken(ctx context.Context, app *firebase.App, env string) *
 	// -----------------------------------
 	// TESTING FUNCTIONALITY
 	// -----------------------------------
-	if env == "testing" {
+	if env == "testing" || env == "debug" {
 		// If this is the correct testing token, return a testing token with fake uid
 		if idToken == "TEST-ID-TOKEN" {
 			return &auth.Token{

--- a/pkg/service/v1/auth.go
+++ b/pkg/service/v1/auth.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/olamai/simulation/pkg/logger"
 
@@ -46,7 +45,6 @@ func verifyFirebaseIDToken(ctx context.Context, app *firebase.App, env string) *
 		return nil
 	}
 	idToken := authTokenHeader[0]
-	fmt.Println("ID TOKEN FOUND: " + idToken)
 	// -----------------------------------
 	// TESTING FUNCTIONALITY
 	// -----------------------------------
@@ -57,7 +55,7 @@ func verifyFirebaseIDToken(ctx context.Context, app *firebase.App, env string) *
 				UID: "TEST-UID",
 			}
 		}
-		// If not, return nil
+		// If not correct test token, return nil
 		return nil
 	}
 	// -----------------------------------

--- a/pkg/service/v1/entity.go
+++ b/pkg/service/v1/entity.go
@@ -14,6 +14,7 @@ const initialHealth = 100
 
 // Create a new entity and add it to the simulation
 func (s *simulationServiceServer) NewEntity(class string, pos Vec2) *Entity {
+	// Create the entity
 	id := s.nextEntityID
 	s.nextEntityID++
 	e := Entity{id, class, pos, initialEnergy, initialHealth}
@@ -45,6 +46,7 @@ func (s *simulationServiceServer) RemoveEntityByID(id int64) bool {
 
 // Move an entity
 func (s *simulationServiceServer) EntityMove(id int64, targetPos Vec2) bool {
+	// Get the entity by id
 	e, ok := s.entities[id]
 
 	// [Start Checks]
@@ -74,6 +76,7 @@ func (s *simulationServiceServer) EntityMove(id int64, targetPos Vec2) bool {
 
 // Entity consume another cell's coccupant
 func (s *simulationServiceServer) EntityConsume(id int64, targetPos Vec2) bool {
+	// Get the entity by id
 	e, ok := s.entities[id]
 
 	// [Start Checks]
@@ -98,4 +101,11 @@ func (s *simulationServiceServer) EntityConsume(id int64, targetPos Vec2) bool {
 	e.energy += 10
 
 	return true
+}
+
+func (s *simulationServiceServer) isCellOccupied(pos Vec2) bool {
+	if _, ok := s.posEntityMap[pos]; ok {
+		return true
+	}
+	return false
 }

--- a/pkg/service/v1/entity.go
+++ b/pkg/service/v1/entity.go
@@ -13,7 +13,7 @@ const initialEnergy = 100
 const initialHealth = 100
 
 // Create a new entity and add it to the simulation
-func (s *simulationServiceServer) NewEntity(class string, pos Vec2) *Entity {
+func (s *simulationServiceServer) newEntity(class string, pos Vec2) *Entity {
 	// Create the entity
 	id := s.nextEntityID
 	s.nextEntityID++
@@ -22,13 +22,13 @@ func (s *simulationServiceServer) NewEntity(class string, pos Vec2) *Entity {
 	s.posEntityMap[pos] = &e
 
 	// Broadcast update
-	s.BroadcastCellUpdate(e.pos, &e, "")
+	s.broadcastCellUpdate(e.pos, &e, "")
 
 	return &e
 }
 
 // Remove an entity by Id and broadcast the update
-func (s *simulationServiceServer) RemoveEntityByID(id int64) bool {
+func (s *simulationServiceServer) removeEntityByID(id int64) bool {
 	// Get the entitiy
 	e, ok := s.entities[id]
 	// Return false if an entitiy by that id doesn't exist
@@ -39,13 +39,13 @@ func (s *simulationServiceServer) RemoveEntityByID(id int64) bool {
 	delete(s.entities, e.id)
 	delete(s.posEntityMap, e.pos)
 	// Broadcast update
-	s.BroadcastCellUpdate(e.pos, nil, "")
+	s.broadcastCellUpdate(e.pos, nil, "")
 
 	return true
 }
 
 // Move an entity
-func (s *simulationServiceServer) EntityMove(id int64, targetPos Vec2) bool {
+func (s *simulationServiceServer) entityMove(id int64, targetPos Vec2) bool {
 	// Get the entity by id
 	e, ok := s.entities[id]
 
@@ -61,7 +61,7 @@ func (s *simulationServiceServer) EntityMove(id int64, targetPos Vec2) bool {
 	// [End Checks]
 
 	// Send to observation
-	s.BroadcastCellUpdate(e.pos, nil, "")
+	s.broadcastCellUpdate(e.pos, nil, "")
 	// Remove entity from current position
 	delete(s.posEntityMap, e.pos)
 
@@ -69,13 +69,13 @@ func (s *simulationServiceServer) EntityMove(id int64, targetPos Vec2) bool {
 	e.pos = targetPos
 	s.posEntityMap[targetPos] = e
 	// Send to observation
-	s.BroadcastCellUpdate(e.pos, e, "")
+	s.broadcastCellUpdate(e.pos, e, "")
 
 	return true
 }
 
 // Entity consume another cell's coccupant
-func (s *simulationServiceServer) EntityConsume(id int64, targetPos Vec2) bool {
+func (s *simulationServiceServer) entityConsume(id int64, targetPos Vec2) bool {
 	// Get the entity by id
 	e, ok := s.entities[id]
 
@@ -88,15 +88,15 @@ func (s *simulationServiceServer) EntityConsume(id int64, targetPos Vec2) bool {
 	targetEntity, ok := s.posEntityMap[targetPos]
 	if !ok {
 		return false
-	} else {
-		if targetEntity.class != "FOOD" {
-			return false
-		}
+	}
+	// Target entity was found, make sure class is consumable
+	if targetEntity.class != "FOOD" {
+		return false
 	}
 	// [End Checks]
 
 	// Remove food entity
-	s.RemoveEntityByID(targetEntity.id)
+	s.removeEntityByID(targetEntity.id)
 	// Add to current entity's energy
 	e.energy += 10
 

--- a/pkg/service/v1/simulation-service.go
+++ b/pkg/service/v1/simulation-service.go
@@ -51,18 +51,18 @@ func NewSimulationServiceServer(env string) v1.SimulationServiceServer {
 		firebaseApp:     initializeFirebaseApp(env),
 	}
 
-	// if env != "testing" {
-	// Spawn food randomly
-	for i := 0; i < 100; i++ {
-		x := int32(rand.Intn(50) - 25)
-		y := int32(rand.Intn(50) - 25)
-		// Don't put anything at 0,0
-		if x == 0 || y == 0 {
-			continue
+	if env != "testing" {
+		// Spawn food randomly
+		for i := 0; i < 100; i++ {
+			x := int32(rand.Intn(50) - 25)
+			y := int32(rand.Intn(50) - 25)
+			// Don't put anything at 0,0
+			if x == 0 || y == 0 {
+				continue
+			}
+			s.NewEntity("FOOD", Vec2{x, y})
 		}
-		s.NewEntity("FOOD", Vec2{x, y})
 	}
-	// }
 
 	return s
 }

--- a/pkg/service/v1/simulation-service_test.go
+++ b/pkg/service/v1/simulation-service_test.go
@@ -35,7 +35,7 @@ func Test_simulationServiceServer_CreateAgent(t *testing.T) {
 				ctx: ctxWithValidToken,
 				req: &v1.CreateAgentRequest{
 					Api: "v1",
-					Agent: &v1.Agent{
+					Agent: &v1.Entity{
 						X: 0,
 						Y: 0,
 					},
@@ -53,7 +53,7 @@ func Test_simulationServiceServer_CreateAgent(t *testing.T) {
 				ctx: ctxWithValidToken,
 				req: &v1.CreateAgentRequest{
 					Api: "v1000",
-					Agent: &v1.Agent{
+					Agent: &v1.Entity{
 						X: 0,
 						Y: 0,
 					},
@@ -68,7 +68,7 @@ func Test_simulationServiceServer_CreateAgent(t *testing.T) {
 				ctx: ctxWithValidToken,
 				req: &v1.CreateAgentRequest{
 					Api: "v1",
-					Agent: &v1.Agent{
+					Agent: &v1.Entity{
 						X: 0,
 						Y: 0,
 					},
@@ -83,7 +83,7 @@ func Test_simulationServiceServer_CreateAgent(t *testing.T) {
 				ctx: ctxWithoutValidToken,
 				req: &v1.CreateAgentRequest{
 					Api: "v1",
-					Agent: &v1.Agent{
+					Agent: &v1.Entity{
 						X: 0,
 						Y: 0,
 					},
@@ -114,7 +114,7 @@ func Test_simulationServiceServer_GetAgent(t *testing.T) {
 	s := NewSimulationServiceServer("testing")
 
 	// Create an agent to test on
-	agent := &v1.Agent{
+	agent := &v1.Entity{
 		X: 2,
 		Y: -4,
 	}
@@ -131,13 +131,13 @@ func Test_simulationServiceServer_GetAgent(t *testing.T) {
 
 	type args struct {
 		ctx context.Context
-		req *v1.GetAgentRequest
+		req *v1.GetEntityRequest
 	}
 	tests := []struct {
 		name    string
 		s       v1.SimulationServiceServer
 		args    args
-		want    *v1.GetAgentResponse
+		want    *v1.GetEntityResponse
 		wantErr bool
 	}{
 		{
@@ -145,14 +145,14 @@ func Test_simulationServiceServer_GetAgent(t *testing.T) {
 			s:    s,
 			args: args{
 				ctx: ctxWithValidToken,
-				req: &v1.GetAgentRequest{
+				req: &v1.GetEntityRequest{
 					Api: "v1",
 					Id:  agentID,
 				},
 			},
-			want: &v1.GetAgentResponse{
-				Api:   "v1",
-				Agent: agent,
+			want: &v1.GetEntityResponse{
+				Api:    "v1",
+				Entity: agent,
 			},
 		},
 		{
@@ -160,7 +160,7 @@ func Test_simulationServiceServer_GetAgent(t *testing.T) {
 			s:    s,
 			args: args{
 				ctx: ctxWithValidToken,
-				req: &v1.GetAgentRequest{
+				req: &v1.GetEntityRequest{
 					Api: "v1000",
 					Id:  agentID,
 				},
@@ -172,7 +172,7 @@ func Test_simulationServiceServer_GetAgent(t *testing.T) {
 			s:    s,
 			args: args{
 				ctx: ctxWithValidToken,
-				req: &v1.GetAgentRequest{
+				req: &v1.GetEntityRequest{
 					Api: "v1",
 					Id:  999,
 				},
@@ -184,20 +184,20 @@ func Test_simulationServiceServer_GetAgent(t *testing.T) {
 			s:    s,
 			args: args{
 				ctx: ctxWithoutValidToken,
-				req: &v1.GetAgentRequest{
+				req: &v1.GetEntityRequest{
 					Api: "v1",
 					Id:  0,
 				},
 			},
-			want: &v1.GetAgentResponse{
-				Api:   "v1",
-				Agent: agent,
+			want: &v1.GetEntityResponse{
+				Api:    "v1",
+				Entity: agent,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.s.GetAgent(tt.args.ctx, tt.args.req)
+			got, err := tt.s.GetEntity(tt.args.ctx, tt.args.req)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("simulationService.Create() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -217,7 +217,7 @@ func Test_simulationServiceServer_DeleteAgent(t *testing.T) {
 	s := NewSimulationServiceServer("testing")
 
 	// Create an agent to test on
-	agent := &v1.Agent{
+	agent := &v1.Entity{
 		X: 2,
 		Y: -4,
 	}

--- a/pkg/service/v1/spectator.go
+++ b/pkg/service/v1/spectator.go
@@ -36,3 +36,25 @@ func (s *simulationServiceServer) isSpectatorAlreadySubscribedToRegion(spectator
 	}
 	return false
 }
+
+// Broadcast a cell update
+func (s *simulationServiceServer) BroadcastCellUpdate(pos Vec2, entity *Entity, action string) {
+	// Get region for this position
+	region := pos.GetRegion()
+	// Get subs for this region
+	subs := s.spectRegionSubs[region]
+	// Loop over and send to channel
+	for _, spectatorID := range subs {
+		channel := s.spectIDChanMap[spectatorID]
+		if entity == nil {
+			channel <- v1.CellUpdate{X: pos.x, Y: pos.y, Entity: nil, Action: action}
+		} else {
+			channel <- v1.CellUpdate{X: pos.x, Y: pos.y, Entity: &v1.Entity{
+				Id:    entity.id,
+				X:     entity.pos.x,
+				Y:     entity.pos.y,
+				Class: entity.class,
+			}, Action: action}
+		}
+	}
+}

--- a/pkg/service/v1/spectator.go
+++ b/pkg/service/v1/spectator.go
@@ -25,12 +25,12 @@ func (s *simulationServiceServer) RemoveSpectatorChannel(id string) {
 }
 
 // Check if a spectator is already subbed to a region
-func (s *simulationServiceServer) isSpectatorAlreadySubscribedToRegion(spectatorId string, region Vec2) bool {
+func (s *simulationServiceServer) isSpectatorAlreadySubscribedToRegion(spectatorID string, region Vec2) bool {
 	// Get subs for this region
 	subs := s.spectRegionSubs[region]
 	// Loop over and send to channel
-	for _, _spectatorId := range subs {
-		if _spectatorId == spectatorId {
+	for _, _spectatorID := range subs {
+		if _spectatorID == spectatorID {
 			return true
 		}
 	}

--- a/pkg/service/v1/spectator.go
+++ b/pkg/service/v1/spectator.go
@@ -3,14 +3,14 @@ package v1
 import v1 "github.com/olamai/simulation/pkg/api/v1"
 
 // Add a spectator channel to the server
-func (s *simulationServiceServer) AddSpectatorChannel(id string) string {
+func (s *simulationServiceServer) addSpectatorChannel(id string) string {
 	// id := uuid.Must(uuid.NewV4()).String()
 	s.spectIDChanMap[id] = make(chan v1.CellUpdate, 100)
 	return id
 }
 
 // Remove a spectator channel from the server AND all it's subscriptions
-func (s *simulationServiceServer) RemoveSpectatorChannel(id string) {
+func (s *simulationServiceServer) removeSpectatorChannel(id string) {
 	// Loop over regions
 	for region, spectatorIDs := range s.spectRegionSubs {
 		// If the user is subscribed to this region, remove their subscription
@@ -38,9 +38,9 @@ func (s *simulationServiceServer) isSpectatorAlreadySubscribedToRegion(spectator
 }
 
 // Broadcast a cell update
-func (s *simulationServiceServer) BroadcastCellUpdate(pos Vec2, entity *Entity, action string) {
+func (s *simulationServiceServer) broadcastCellUpdate(pos Vec2, entity *Entity, action string) {
 	// Get region for this position
-	region := pos.GetRegion()
+	region := pos.getRegion()
 	// Get subs for this region
 	subs := s.spectRegionSubs[region]
 	// Loop over and send to channel

--- a/pkg/service/v1/utils.go
+++ b/pkg/service/v1/utils.go
@@ -17,7 +17,7 @@ type Vec2 struct {
 }
 
 // GetRegion - Returns the region that a position is in
-func (v *Vec2) GetRegion() Vec2 {
+func (v *Vec2) getRegion() Vec2 {
 	x := v.x
 	y := v.y
 	var signX int32 = 1
@@ -32,7 +32,7 @@ func (v *Vec2) GetRegion() Vec2 {
 }
 
 // GetPositionsInRegion - Returns all positions that are in a specfic region
-func (v *Vec2) GetPositionsInRegion() ([]int32, []int32) {
+func (v *Vec2) getPositionsInRegion() ([]int32, []int32) {
 	xs := []int32{}
 	ys := []int32{}
 	var signX int32 = 1
@@ -88,7 +88,7 @@ func newUUID() (string, error) {
 // ---------------------
 
 // Get all observations for a specific position
-func (s *simulationServiceServer) GetObservationCellsForPosition(pos Vec2) []string {
+func (s *simulationServiceServer) getObservationCellsForPosition(pos Vec2) []string {
 	var cells []string
 	// TODO - implement this
 	for y := pos.y + 1; y >= pos.y-1; y-- {

--- a/pkg/service/v1/utils.go
+++ b/pkg/service/v1/utils.go
@@ -7,15 +7,16 @@ import (
 )
 
 const (
-	REGION_SIZE = 5
+	regionSize = 10
 )
 
-// Simple struct for holding positions
+// Vec2 - Simple struct for holding positions
 type Vec2 struct {
 	x int32
 	y int32
 }
 
+// GetRegion - Returns the region that a position is in
 func (v *Vec2) GetRegion() Vec2 {
 	x := v.x
 	y := v.y
@@ -30,6 +31,7 @@ func (v *Vec2) GetRegion() Vec2 {
 	return Vec2{x/10 + signX, y/10 + signY}
 }
 
+// GetPositionsInRegion - Returns all positions that are in a specfic region
 func (v *Vec2) GetPositionsInRegion() ([]int32, []int32) {
 	xs := []int32{}
 	ys := []int32{}
@@ -41,10 +43,10 @@ func (v *Vec2) GetPositionsInRegion() ([]int32, []int32) {
 	if v.y < 0 {
 		signY = -1
 	}
-	startX := (v.x - signX) * REGION_SIZE
-	startY := (v.y - signY) * REGION_SIZE
-	endX := v.x * REGION_SIZE
-	endY := v.y * REGION_SIZE
+	startX := (v.x - signX) * regionSize
+	startY := (v.y - signY) * regionSize
+	endX := v.x * regionSize
+	endY := v.y * regionSize
 	if signX > 0 {
 		for x := startX; x < endX; x++ {
 			xs = append(xs, x)


### PR DESCRIPTION
Data races have been fixed by adding a mutex lock to the simulationServiceServer struct. Data is only locked on API calls and eventually will lock on simulation runtime
All unnecessary logs have been removed
Graceful stop issue that caused the server to hang when trying to close down is fixed, now stops forcefully
Refactored non-api calls to be lowercase